### PR TITLE
Update the Maven Jar plugin to 3.2.0

### DIFF
--- a/ki-shell/pom.xml
+++ b/ki-shell/pom.xml
@@ -164,7 +164,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.6</version>
+        <version>3.2.0</version>
         <configuration>
           <archive>
             <manifest>


### PR DESCRIPTION
The current implicit version (2.6.0) doesn't build on M1 arm chips.

Closes https://github.com/Kotlin/kotlin-interactive-shell/issues/63