### PR TITLE
Fix #61

### DIFF
--- a/bin/ki.bat
+++ b/bin/ki.bat
@@ -1,6 +1,6 @@
 @echo off
 
 set SCRIPT_PATH=%~dp0
-set KI_SHELL=%SCRIPT_PATH%\..\lib\ki-shell-*.jar
+set KI_SHELL=%SCRIPT_PATH%\..\lib\ki-shell.jar
 
 java -jar %KI_SHELL% %*

--- a/bin/ki.sh
+++ b/bin/ki.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-KI_SHELL=$SCRIPT_DIR/../lib/ki-shell-*.jar
+KI_SHELL=$SCRIPT_DIR/../lib/ki-shell.jar
 
 java -jar ${KI_SHELL} $@

--- a/ki-shell/pom.xml
+++ b/ki-shell/pom.xml
@@ -188,7 +188,7 @@
               <artifactSet>
                 <includes />
               </artifactSet>
-              <outputFile>${project.parent.basedir}/lib/${project.artifactId}-${project.version}.jar</outputFile>
+              <outputFile>${project.parent.basedir}/lib/${project.artifactId}.jar</outputFile>
             </configuration>
           </execution>
         </executions>

--- a/ki-shell/src/assembly/bin.xml
+++ b/ki-shell/src/assembly/bin.xml
@@ -14,7 +14,7 @@
       <outputDirectory>bin</outputDirectory>
     </file>
     <file>
-      <source>lib/${project.artifactId}-${project.version}.jar</source>
+      <source>lib/${project.artifactId}.jar</source>
       <outputDirectory>lib</outputDirectory>
     </file>
   </files>


### PR DESCRIPTION
We don't need to have `ki-shell-$version.jar` in `lib` dir, `ki-shell.jar` will be enough.