### PR TITLE
fixed kit.bat for paths containing spaces

### DIFF
--- a/bin/ki.bat
+++ b/bin/ki.bat
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 set SCRIPT_DIR=%~dp0
-set KI_SHELL=%SCRIPT_DIR%\..\lib\ki-shell.jar
+set KI_SHELL="%SCRIPT_DIR%\..\lib\ki-shell.jar"
 set JAVA_OPTS=%*
 
 for /f "tokens=3" %%g in ('java -version 2^>^&1 ^| findstr /i "version"') do (


### PR DESCRIPTION
when the folder where the KI was located contained spaces, the KI would not start and would show "Error: Unable to access jarfile"