### PR TITLE
rollback kotlin-scripting-dependencies-maven-all to old version

### DIFF
--- a/ki-shell/pom.xml
+++ b/ki-shell/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-scripting-dependencies-maven-all</artifactId>
+      <artifactId>kotlin-scripting-dependencies-maven</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>


### PR DESCRIPTION
Rollback to previous version fixes issue with :dependsOn command broken by kotlin-scripting-dependencies-maven-all dependency.