### PR TITLE
kotlin-scripting-dependencies-maven-all restored, slf4j dependencies added

### DIFF
--- a/ki-shell/pom.xml
+++ b/ki-shell/pom.xml
@@ -59,7 +59,7 @@
     </dependency>
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
-      <artifactId>kotlin-scripting-dependencies-maven</artifactId>
+      <artifactId>kotlin-scripting-dependencies-maven-all</artifactId>
       <version>${kotlin.version}</version>
     </dependency>
     <dependency>
@@ -86,6 +86,16 @@
       <groupId>org.antlr</groupId>
       <artifactId>antlr4-runtime</artifactId>
       <version>4.8-1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.33</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.33</version>
     </dependency>
 
   </dependencies>


### PR DESCRIPTION
Make kotlin-scripting-dependencies-maven-all great again, slf4j dependencies added in order to fix :dependsOn command error.