### PR TITLE
Upgraded Kotlin version to 1.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <module>ki-shell</module>
   </modules>
   <properties>
-    <kotlin.version>1.7.0</kotlin.version>
+    <kotlin.version>1.9.0</kotlin.version>
     <jvm.version>11</jvm.version>
   </properties>
   <build>


### PR DESCRIPTION
This simply tries to update the Kotlin version to 1.9.0 and hopefully nothing brakes.

Fix #128 
